### PR TITLE
Update update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -121,8 +121,8 @@ if diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; then
     exit $?
 fi
 
-if [ -f /boot/adsb-config.txt ]; then
-    source /boot/adsb-config.txt
+if [ -f /boot/adsbfi-env ]; then
+#    source /boot/adsb-config.txt
     source /boot/adsbfi-env
 else
     source /etc/default/adsbfi


### PR DESCRIPTION
Script fails if /boot/adsb-config.txt exists but /boot/adsbfi-env does not. This is the case on an initial run.  I propose:
Do not check for /boot adsb-config.txt in the configuration. Simply use /boot/adsbfi-env if it exists, /etc/default/adsbfi otherwise.