### PR TITLE
Switched readsb from master to dev

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -270,7 +270,7 @@ echo 70
 # SETUP FEEDER TO SEND DUMP1090 DATA TO adsb.fi
 
 READSB_REPO="https://github.com/adsbfi/readsb.git"
-READSB_BRANCH="master"
+READSB_BRANCH="dev"
 if grep -E 'wheezy|jessie' /etc/os-release -qs; then
     READSB_BRANCH="jessie"
 fi


### PR DESCRIPTION
I switched the branch for https://github.com/adsbfi/readsb from master to dev. There is no master branch for that repo.

Since master isn't found, this throws an error after step 74:

```
72
-----------------------------------------------
Now compiling code can take a few minutes
-----------------------------------------------
74
fatal: not a git repository (or any of the parent directories): .git
```

I changed /usr/local/share/adsbfi/git/update.sh locally and was able to successfully start feeding adsb.fi with this change.